### PR TITLE
feat: 멤버관련 uuid 일괄 추가, fk 제거

### DIFF
--- a/ssgserver/src/main/java/com/isekai/ssgserver/bundle/entity/Bundle.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/bundle/entity/Bundle.java
@@ -25,7 +25,7 @@ public class Bundle {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "bundle_id")
-	private long bundleId;
+	private Long bundleId;
 
 	@Column(name = "outer_name", nullable = false)
 	private String outerName;
@@ -40,13 +40,13 @@ public class Bundle {
 	private int minPrice;
 
 	@Column(name = "review_count", nullable = false)
-	private long reviewCount;
+	private Long reviewCount;
 
 	@Column(name = "avg_score", nullable = false)
 	private double avgScore;
 
 	@Column(name = "buy_count")
-	private long buyCount;
+	private Long buyCount;
 
 	@Column(name = "delivery_type", nullable = false)
 	private byte deliveryType;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/cart/entity/Cart.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/cart/entity/Cart.java
@@ -2,7 +2,6 @@ package com.isekai.ssgserver.cart.entity;
 
 import java.time.LocalDateTime;
 
-import com.isekai.ssgserver.member.entity.Memeber;
 import com.isekai.ssgserver.option.entity.Option;
 
 import jakarta.persistence.Column;
@@ -32,7 +31,10 @@ public class Cart {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "cart_id")
-	private long cartId;
+	private Long cartId;
+
+	@Column(nullable = false)
+	private String uuid;
 
 	@Column(nullable = false)
 	private int count;
@@ -44,10 +46,6 @@ public class Cart {
 	private LocalDateTime createdAt;
 
 	// 연관 관계
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id", nullable = false)
-	private Memeber memeber;
-
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "options_id", nullable = false)
 	private Option option;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/category/entity/CategoryL.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/category/entity/CategoryL.java
@@ -25,7 +25,7 @@ public class CategoryL {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "category_l_id")
-	private long categoryLId;
+	private Long categoryLId;
 
 	@Column(name = "large_name", nullable = false)
 	private String largeName;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/category/entity/CategoryM.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/category/entity/CategoryM.java
@@ -28,7 +28,7 @@ public class CategoryM {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "category_m_id")
-	private long categoryMId;
+	private Long categoryMId;
 
 	@Column(name = "medium_name", nullable = false)
 	private String mediumName;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/category/entity/CategoryS.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/category/entity/CategoryS.java
@@ -28,7 +28,7 @@ public class CategoryS {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "category_s_id")
-	private long categorySId;
+	private Long categorySId;
 
 	@Column(name = "small_name", nullable = false)
 	private String smallName;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/coupon/entity/Coupon.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/coupon/entity/Coupon.java
@@ -28,7 +28,7 @@ public class Coupon {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "coupon_id")
-	private long couponId;
+	private Long couponId;
 
 	@Column(name = "name", nullable = false)
 	private String name;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/delivery/entity/Delivery.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/delivery/entity/Delivery.java
@@ -31,9 +31,9 @@ public class Delivery {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "delivery_id")
-	private long deliveryId;
+	private Long deliveryId;
 
-	private long status;
+	private Long status;
 
 	// @Column(name = "Filed")
 	private byte filed;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/delivery/entity/DeliveryType.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/delivery/entity/DeliveryType.java
@@ -25,7 +25,7 @@ public class DeliveryType {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "delivery_type_id")
-	private long deliveryTypeId;
+	private Long deliveryTypeId;
 
 	@Column(name = "name", nullable = false)
 	private String name;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/delivery/entity/ProductDeliveryType.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/delivery/entity/ProductDeliveryType.java
@@ -30,7 +30,7 @@ public class ProductDeliveryType {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "product_delivery_type_id")
-	private long productDeliveryTypeId;
+	private Long productDeliveryTypeId;
 
 	// 연관 관계
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/ssgserver/src/main/java/com/isekai/ssgserver/deliveryAddress/entity/DeliveryAddress.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/deliveryAddress/entity/DeliveryAddress.java
@@ -25,10 +25,10 @@ public class DeliveryAddress {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "delivery_address_id")
-	private long deliveryAddressId;
+	private Long deliveryAddressId;
 
 	@Column(name = "member_id")
-	private long memeberId;
+	private Long memeberId;
 
 	@Column(name = "nickname", nullable = false)
 	private String nickname;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/image/entity/Image.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/image/entity/Image.java
@@ -25,7 +25,7 @@ public class Image {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "image_id")
-	private long imageId;
+	private Long imageId;
 
 	@Column(name = "image_url", nullable = false)
 	private String imageUrl;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/jwt/service/JwtProvider.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/jwt/service/JwtProvider.java
@@ -22,10 +22,10 @@ public class JwtProvider {
 	private String secretKey;
 
 	@Value("${jwt.token.access-expire-time}")
-	private long accessExpireTime;
+	private Long accessExpireTime;
 
 	@Value("${jwt.token.refresh-expire-time}")
-	private long refreshExpireTime;
+	private Long refreshExpireTime;
 
 	private final RedisService redisService;
 

--- a/ssgserver/src/main/java/com/isekai/ssgserver/member/entity/Favorite.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/member/entity/Favorite.java
@@ -4,12 +4,9 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -30,20 +27,18 @@ public class Favorite {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "favorite_id")
-	private long favoriteId;
+	private Long favoriteId;
+
+	@Column(nullable = false)
+	private String uuid;
 
 	@Column(name = "division", nullable = false)
 	private byte division;
 
 	@Column(name = "product_id", nullable = false)
-	private long productId;
+	private Long productId;
 
 	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
-
-	// 연관 관계
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id", nullable = false)
-	private Memeber member;
 
 }

--- a/ssgserver/src/main/java/com/isekai/ssgserver/member/entity/MarketingAgree.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/member/entity/MarketingAgree.java
@@ -4,12 +4,9 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -29,8 +26,13 @@ public class MarketingAgree {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String uuid;
+
 	@Column(name = "member_agree_id")
-	private long memberAgree;
+	private Long memberAgree;
 
 	@Column(name = "email", nullable = false)
 	private byte email;
@@ -40,9 +42,4 @@ public class MarketingAgree {
 
 	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
-
-	// 연관 관계
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id", nullable = false)
-	private Memeber memeber;
 }

--- a/ssgserver/src/main/java/com/isekai/ssgserver/member/entity/MemberSocial.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/member/entity/MemberSocial.java
@@ -2,12 +2,9 @@ package com.isekai.ssgserver.member.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -28,16 +25,14 @@ public class MemberSocial {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "member_social_id")
-	private long memberSocialId;
+	private Long memberSocialId;
+
+	@Column(nullable = false)
+	private String uuid;
 
 	@Column(name = "member_social_code", nullable = false)
 	private String memberSocialCode;
 
 	@Column(name = "socail_division_code", nullable = false)
 	private byte socailDivisionCode;
-
-	// 연관 관계
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id", nullable = false)
-	private Memeber member;
 }

--- a/ssgserver/src/main/java/com/isekai/ssgserver/member/entity/Memeber.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/member/entity/Memeber.java
@@ -27,7 +27,10 @@ public class Memeber {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "member_id")
-	private long memberId;
+	private Long memberId;
+
+	@Column(unique = true, nullable = false, updatable = false)
+	private String uuid;
 
 	@Column(name = "account_id", nullable = false)
 	private String accountId;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/member/entity/MemeberCoupon.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/member/entity/MemeberCoupon.java
@@ -32,7 +32,10 @@ public class MemeberCoupon {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "member_coupon_id")
-	private long memberCouponId;
+	private Long memberCouponId;
+
+	@Column(nullable = false)
+	private String uuid;
 
 	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
@@ -44,10 +47,6 @@ public class MemeberCoupon {
 	private int quantity;
 
 	// 연관 관계
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id", nullable = false)
-	private Memeber memeber;
-
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "coupon_id", nullable = false)
 	private Coupon coupon;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/member/entity/Question.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/member/entity/Question.java
@@ -30,7 +30,10 @@ public class Question {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "question_id")
-	private long questionId;
+	private Long questionId;
+
+	@Column(nullable = false)
+	private String uuid;
 
 	@Column(name = "division", nullable = false)
 	private byte division;
@@ -42,10 +45,6 @@ public class Question {
 	private String title;
 
 	// 연관 관계
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id", nullable = false)
-	private Memeber member;
-
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "product_id", nullable = false)
 	private Product product;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/member/entity/WithdrawInfo.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/member/entity/WithdrawInfo.java
@@ -2,12 +2,9 @@ package com.isekai.ssgserver.member.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -28,12 +25,9 @@ public class WithdrawInfo {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "withdraw_info_id")
-	private long withdrawInfoId;
+	private Long withdrawInfoId;
+
+	private String uuid;
 
 	private String reason;
-
-	// 연관 관계
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id", nullable = false)
-	private Memeber memeber;
 }

--- a/ssgserver/src/main/java/com/isekai/ssgserver/option/entity/Option.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/option/entity/Option.java
@@ -32,7 +32,7 @@ public class Option {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "options_id")
-	private long optionsId;
+	private Long optionsId;
 
 	@Column(name = "value", nullable = false)
 	private String value;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/option/entity/OptionFirst.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/option/entity/OptionFirst.java
@@ -24,7 +24,7 @@ public class OptionFirst {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "option_first_id")
-	private long optionFirstId;
+	private Long optionFirstId;
 
 	@Column(name = "division", nullable = false)
 	private String division;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/option/entity/OptionSecond.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/option/entity/OptionSecond.java
@@ -24,7 +24,7 @@ public class OptionSecond {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "option_second_id")
-	private long optionSecondId;
+	private Long optionSecondId;
 
 	@Column(name = "division", nullable = false)
 	private String division;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/option/entity/OptionThird.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/option/entity/OptionThird.java
@@ -24,7 +24,7 @@ public class OptionThird {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "option_third_id")
-	private long optionThirdId;
+	private Long optionThirdId;
 
 	@Column(name = "division", nullable = false)
 	private String division;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/order/entity/Order.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/order/entity/Order.java
@@ -24,16 +24,16 @@ public class Order {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "orders_id")
-	private long ordersId;
+	private Long ordersId;
 
 	@Column(name = "member_id", nullable = false)
-	private long memberId;
+	private Long memberId;
 
 	@Column(name = "code", nullable = false)
 	private String code;
 
 	@Column(name = "member_coupon_id")
-	private long memeberCouponId;
+	private Long memeberCouponId;
 
 	@Column(name = "regular_price", nullable = false)
 	private int regularPrice;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/order/entity/OrderProduct.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/order/entity/OrderProduct.java
@@ -31,7 +31,7 @@ public class OrderProduct {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "order_product_id")
-	private long orderProductId;
+	private Long orderProductId;
 
 	@Column(name = "count", nullable = false)
 	private int count;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/product/entity/Discount.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/product/entity/Discount.java
@@ -29,7 +29,7 @@ public class Discount {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "discount_id")
-	private long discountId;
+	private Long discountId;
 
 	@Column(name = "discount_rate", nullable = false)
 	private int discountRate;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/product/entity/Product.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/product/entity/Product.java
@@ -24,7 +24,7 @@ public class Product {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "product_id")
-	private long productId;
+	private Long productId;
 
 	@Column(name = "product_name", nullable = false)
 	private String productName;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/product/entity/ProductInfo.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/product/entity/ProductInfo.java
@@ -28,7 +28,7 @@ public class ProductInfo {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "product_info_id")
-	private long productInfoId;
+	private Long productInfoId;
 
 	@Column(name = "keyword", nullable = false)
 	private String keyword;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/product/entity/ProductKeyword.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/product/entity/ProductKeyword.java
@@ -28,7 +28,7 @@ public class ProductKeyword {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "product_keyword_id")
-	private long productKeywordId;
+	private Long productKeywordId;
 
 	@Column(name = "name", nullable = false)
 	private String name;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/product/entity/RecentView.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/product/entity/RecentView.java
@@ -2,10 +2,6 @@ package com.isekai.ssgserver.product.entity;
 
 import java.time.LocalDateTime;
 
-import org.springframework.cglib.core.Local;
-
-import com.isekai.ssgserver.member.entity.Memeber;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -34,16 +30,15 @@ public class RecentView {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "recent_view_id")
-	private long recentViewId;
+	private Long recentViewId;
+
+	@Column(nullable = false)
+	private String uuid;
 
 	@Column(name = "created_at")
 	private LocalDateTime createdAt;
 
 	// 연관 관계
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id", nullable = false)
-	private Memeber member;
-
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "product_id", nullable = false)
 	private Product product;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/report/entity/Report.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/report/entity/Report.java
@@ -24,7 +24,7 @@ public class Report {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "report_id")
-	private long reportId;
+	private Long reportId;
 
 	@Column(name = "division", nullable = false)
 	private byte division;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/review/entity/Review.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/review/entity/Review.java
@@ -30,10 +30,10 @@ public class Review {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "review_id")
-	private long rewiewId;
+	private Long rewiewId;
 
 	@Column(name = "member_id", nullable = false)
-	private long memberId;
+	private Long memberId;
 
 	@Column(name = "account_id", nullable = false)
 	private String accountId;
@@ -48,7 +48,7 @@ public class Review {
 	private String reviewImage;
 
 	@Column(name = "product_id")
-	private long productId;
+	private Long productId;
 
 	// 연관 관계
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/ssgserver/src/main/java/com/isekai/ssgserver/review/entity/ReviewScore.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/review/entity/ReviewScore.java
@@ -30,13 +30,13 @@ public class ReviewScore {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "total_score_id")
-	private long totalScoreId;
+	private Long totalScoreId;
 
 	@Column(name = "review_count", nullable = false)
-	private long reviewCount;
+	private Long reviewCount;
 
 	@Column(name = "total_score", nullable = false)
-	private long totalScore;
+	private Long totalScore;
 
 	@Column(name = "avg_score", nullable = false)
 	private double avgScore;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/review/entity/TotalPurchase.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/review/entity/TotalPurchase.java
@@ -30,16 +30,16 @@ public class TotalPurchase {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "total_purchase_id")
-	private long totalPurchaseId;
+	private Long totalPurchaseId;
 
 	@Column(name = "count", nullable = false)
 	private int count;
 
 	@Column(name = "cur_rank")
-	private long curRank;
+	private Long curRank;
 
 	@Column(name = "pre_rank")
-	private long preRank;
+	private Long preRank;
 
 	// 연관 관계
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/ssgserver/src/main/java/com/isekai/ssgserver/seller/entity/Seller.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/seller/entity/Seller.java
@@ -25,7 +25,7 @@ public class Seller {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "seller_id")
-	private long sellerId;
+	private Long sellerId;
 
 	@Column(name = "name", nullable = false)
 	private String name;

--- a/ssgserver/src/main/java/com/isekai/ssgserver/seller/entity/SellerProduct.java
+++ b/ssgserver/src/main/java/com/isekai/ssgserver/seller/entity/SellerProduct.java
@@ -30,7 +30,7 @@ public class SellerProduct {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "seller_product_id")
-	private long sellerProductId;
+	private Long sellerProductId;
 
 	private String status;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #19 

## 📝작업 내용

> 회원을 식별할 때 보안 상 이유로 pk 대신 uuid를 사용하기로 했습니다. 이에 따라 DB 및 Entity 설정을 바꾸었습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


